### PR TITLE
fix: Prevent accidental deletion of new attachments during replacement

### DIFF
--- a/src/Concerns/HasAttachments.php
+++ b/src/Concerns/HasAttachments.php
@@ -8,6 +8,8 @@ use NiftyCo\Attachments\Attachments;
 
 trait HasAttachments
 {
+    use HasAttachmentCleanup;
+
     /**
      * Attach a file to the specified attribute.
      */

--- a/tests/Feature/AttachmentModelIntegrationTest.php
+++ b/tests/Feature/AttachmentModelIntegrationTest.php
@@ -9,6 +9,7 @@ use NiftyCo\Attachments\Attachment;
 use NiftyCo\Attachments\Attachments;
 use NiftyCo\Attachments\Casts\AsAttachment;
 use NiftyCo\Attachments\Casts\AsAttachments;
+use NiftyCo\Attachments\Concerns\HasAttachmentCleanup;
 
 beforeEach(function () {
     Storage::fake('public');
@@ -159,6 +160,8 @@ function createDocumentModel(): Model
 {
     $model = new class extends Model
     {
+        use HasAttachmentCleanup;
+
         protected $table = 'documents';
         protected $guarded = [];
 

--- a/tests/Unit/AttachmentReplacementTest.php
+++ b/tests/Unit/AttachmentReplacementTest.php
@@ -177,27 +177,27 @@ it('does not delete new attachment when replacing via request pattern', function
     $existingAttachment = Attachment::fromFile($existingFile, 'public');
     $model->avatar = $existingAttachment;
     $model->save();
-    
+
     $existingPath = $existingAttachment->path();
     expect(Storage::disk('public')->exists($existingPath))->toBeTrue();
-    
+
     // Now simulate the request pattern (no refresh - same model instance)
     $newFile = UploadedFile::fake()->image('new-avatar.jpg');
     $newAttachment = Attachment::fromFile($newFile, 'public');
     $newPath = $newAttachment->path();
-    
+
     // File should exist immediately after fromFile
     expect(Storage::disk('public')->exists($newPath))->toBeTrue();
-    
+
     // Now set it on the model (this triggers the cast's set method)
     $model->avatar = $newAttachment;
-    
+
     // New file should STILL exist after assignment
     expect(Storage::disk('public')->exists($newPath))->toBeTrue();
-    
+
     // Save the model
     $model->save();
-    
+
     // After save: old should be deleted, new should exist
     expect(Storage::disk('public')->exists($existingPath))->toBeFalse();
     expect(Storage::disk('public')->exists($newPath))->toBeTrue();

--- a/tests/Unit/AttachmentReplacementTest.php
+++ b/tests/Unit/AttachmentReplacementTest.php
@@ -154,3 +154,51 @@ it('does not delete old attachment when delete_on_replace is disabled', function
     // New file should also exist
     expect(Storage::disk('public')->exists($attachment2->path()))->toBeTrue();
 });
+
+it('does not delete new attachment when replacing via request pattern', function () {
+    config(['attachments.delete_on_replace' => true]);
+
+    $model = new class extends Model
+    {
+        protected $table = 'test_models';
+
+        protected $guarded = [];
+
+        protected function casts(): array
+        {
+            return [
+                'avatar' => AsAttachment::class,
+            ];
+        }
+    };
+
+    // Simulate: user already exists with an avatar
+    $existingFile = UploadedFile::fake()->image('existing-avatar.jpg');
+    $existingAttachment = Attachment::fromFile($existingFile, 'public');
+    $model->avatar = $existingAttachment;
+    $model->save();
+    
+    $existingPath = $existingAttachment->path();
+    expect(Storage::disk('public')->exists($existingPath))->toBeTrue();
+    
+    // Now simulate the request pattern (no refresh - same model instance)
+    $newFile = UploadedFile::fake()->image('new-avatar.jpg');
+    $newAttachment = Attachment::fromFile($newFile, 'public');
+    $newPath = $newAttachment->path();
+    
+    // File should exist immediately after fromFile
+    expect(Storage::disk('public')->exists($newPath))->toBeTrue();
+    
+    // Now set it on the model (this triggers the cast's set method)
+    $model->avatar = $newAttachment;
+    
+    // New file should STILL exist after assignment
+    expect(Storage::disk('public')->exists($newPath))->toBeTrue();
+    
+    // Save the model
+    $model->save();
+    
+    // After save: old should be deleted, new should exist
+    expect(Storage::disk('public')->exists($existingPath))->toBeFalse();
+    expect(Storage::disk('public')->exists($newPath))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- Add safeguard in `AsAttachment` and `AsAttachments` casts to compare old and new attachment paths before deletion, preventing the new attachment from being accidentally deleted when it shares the same path as the old one
- Fix null handling so setting attachments to `null` properly deletes old attachments when `delete_on_replace` is enabled
- Make `HasAttachments` trait include `HasAttachmentCleanup` so models automatically get cleanup behavior on deletion